### PR TITLE
Add error return value to Set operation

### DIFF
--- a/tracker.go
+++ b/tracker.go
@@ -99,9 +99,9 @@ func (s *TrackerCache) Get(key string, buf []byte) []byte {
 	return result
 }
 
-func (s *TrackerCache) Set(key string, val []byte) {
+func (s *TrackerCache) Set(key string, val []byte) error {
 	s.sets.Add(1)
-	s.inner.Set(key, val)
+	return s.inner.Set(key, val)
 }
 
 func (s *TrackerCache) Has(key string) bool {


### PR DESCRIPTION
This change adds visibility to the Set operation to recognize when a value is not added to the cache and find the reason instead of failing silently.