### PR TITLE
fix: make overflow of int32

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -156,7 +156,7 @@ func NewEx(slotSize, mCap, sCap int32) Cache {
 	slotCap := mCap + sCap
 
 	c := &cache{
-		data:     make([]byte, slotCap*slotSize),
+		data:     make([]byte, int64(slotCap)*int64(slotSize)),
 		eAccess:  make([]atomic.Int32, slotCap),
 		eFreq:    make([]atomic.Int32, slotCap),
 		eSize:    make([]int32, slotCap),


### PR DESCRIPTION
int32 * int32 could cause an overflow when working with big slotSizes and / or big slotCounts.